### PR TITLE
A few updates (details in description)

### DIFF
--- a/dapp/src/app/components/machines/candybag-machine/useSugarMarketPrice.ts
+++ b/dapp/src/app/components/machines/candybag-machine/useSugarMarketPrice.ts
@@ -41,19 +41,19 @@ export const useSugarMarketPrice = () => {
 
       const normalized_time = time % (2 * half_period)
 
-      const max_value = 5
-      const epsilon = 0.1
+      const max_value = 20
+      const epsilon = 10
 
       let price = 0
 
       if (normalized_time < half_period)
-        price = (normalized_time * max_value) / half_period 
+        price = (normalized_time / half_period) * max_value
       else
-        price =
+        price = 
           max_value -
-          ((normalized_time - half_period) * max_value) / half_period
+          (((normalized_time - half_period) / half_period) * max_value) 
 
-      if (price === 0) {
+      if (price < epsilon) {
           price += epsilon;
       }
         

--- a/scrypto/gumball_club/src/gumball_club.rs
+++ b/scrypto/gumball_club/src/gumball_club.rs
@@ -82,10 +82,11 @@ mod gumball_club {
             // This resource has no finite supply.
             let gumball_club_token_manager: ResourceManager = 
                 ResourceBuilder::new_fungible(owner_role.clone())
-                .divisibility(DIVISIBILITY_MAXIMUM)
+                .divisibility(DIVISIBILITY_NONE)
                 .metadata(metadata!(
                     init {
                         "name" => "Gumball Club Tokens", locked;
+                        "description" => "Use GC tokens to purchase gumballs and candies from the sweet machines", locked;
                         "symbol" => "GC", locked;
                     }
                 ))
@@ -184,7 +185,7 @@ mod gumball_club {
         /// * `Bucket` - Returns a `Bucket` of Gumball Club token at hardcoded amount of 20.
         pub fn dispense_gc_tokens(&mut self) -> Bucket {
             let gumball_club_tokens = self.gumball_club_token_manager.mint(dec!(20));
-
+            
             return gumball_club_tokens
         }
 

--- a/scrypto/gumball_club/src/gumball_machine.rs
+++ b/scrypto/gumball_club/src/gumball_machine.rs
@@ -192,7 +192,7 @@ mod gumball_machine {
         /// 1. Any refunded/leftover payments to the user.
         /// 2. The `Bucket` of gumballs.
         pub fn buy_gumball(&mut self, mut payment: Bucket) -> (Bucket, Bucket) {
-
+            
             let resource_name_metadata: String = 
                 self.collected_tokens
                     .resource_manager()

--- a/scrypto/gumball_club/tests/candy-machine.rs
+++ b/scrypto/gumball_club/tests/candy-machine.rs
@@ -406,19 +406,19 @@ pub fn buy_candy() {
 
         let price_vec: Vec<Decimal> = 
             vec![
-                dec!("0.1"),
-                dec!("1.66"),
-                dec!("3.33"),
-                dec!("5"),
-                dec!("3.33"),
-                dec!("1.66"),
-                dec!("0.1"),
-                dec!("1.66"),
-                dec!("3.33"),
-                dec!("5"),
-                dec!("3.33"),
-                dec!("1.66"),
-                dec!("0.1"),
+                dec!("10"),
+                dec!("16.66"),
+                dec!("13.33"),
+                dec!("20"),
+                dec!("13.33"),
+                dec!("16.66"),
+                dec!("10"),
+                dec!("16.66"),
+                dec!("13.33"),
+                dec!("20"),
+                dec!("13.33"),
+                dec!("16.66"),
+                dec!("10"),
             ];
 
         let mut index = (proposer_timestamp_ms / 600000).try_into().unwrap();
@@ -430,20 +430,21 @@ pub fn buy_candy() {
         // Candy amount is hand-calculated by price * payment amount (Rounded to 0 decimal points to zero)
         // Payment amount is assumed to be 5 GC per transaction for this test.
         let candy_amount_vec: Vec<Decimal> = vec![
-            dec!("0"),
-            dec!("8"),
-            dec!("16"),
-            dec!("25"),
-            dec!("16"),
-            dec!("8"),
-            dec!("0"),
-            dec!("8"),
-            dec!("16"),
-            dec!("25"),
-            dec!("16"),
-            dec!("8"),
-            dec!("0"),
+            dec!("50"),
+            dec!("83"),
+            dec!("66"),
+            dec!("100"),
+            dec!("66"),
+            dec!("83"),
+            dec!("50"),
+            dec!("83"),
+            dec!("66"),
+            dec!("100"),
+            dec!("66"),
+            dec!("83"),
+            dec!("50"),
         ];
+
 
         let candy_amount = 
             dec!(5) // Payment amount
@@ -507,23 +508,23 @@ pub fn buy_candy_with_member_card() {
 
         let price_vec: Vec<Decimal> = 
             vec![
-                dec!("0.1"),
-                dec!("1.66"),
-                dec!("3.33"),
-                dec!("5"),
-                dec!("3.33"),
-                dec!("1.66"),
-                dec!("0.1"),
-                dec!("1.66"),
-                dec!("3.33"),
-                dec!("5"),
-                dec!("3.33"),
-                dec!("1.66"),
-                dec!("0.1"),
-                ];
+                dec!("20"),
+                dec!("33.32"),
+                dec!("26.66"),
+                dec!("40"),
+                dec!("26.66"),
+                dec!("33.32"),
+                dec!("20"),
+                dec!("33.32"),
+                dec!("26.66"),
+                dec!("40"),
+                dec!("26.66"),
+                dec!("33.32"),
+                dec!("20"),
+            ];
 
         let mut index = (proposer_timestamp_ms / 600000).try_into().unwrap();
-
+    
         if index >= price_vec.len() {
             index = 0;
         }
@@ -536,19 +537,19 @@ pub fn buy_candy_with_member_card() {
             .unwrap();
 
         let candy_amount_vec: Vec<Decimal> = vec![
-            dec!("1"),
-            dec!("16"),
-            dec!("33"),
-            dec!("50"),
-            dec!("33"),
-            dec!("16"),
-            dec!("1"),
-            dec!("16"),
-            dec!("33"),
-            dec!("50"),
-            dec!("33"),
-            dec!("16"),
-            dec!("1"),
+            dec!("100"),
+            dec!("166"),
+            dec!("133"),
+            dec!("200"),
+            dec!("133"),
+            dec!("166"),
+            dec!("100"),
+            dec!("166"),
+            dec!("133"),
+            dec!("200"),
+            dec!("133"),
+            dec!("166"),
+            dec!("100"),
         ];
 
         let candy_amount = 


### PR DESCRIPTION
* Updated candy price calculation such that sending 1 token will always have minimum 10 candies
* Updated tests to reflect this
* Updated JS candy price calculation to mirror backend calculation
* Updated Gumball Club token to no longer be divisible (can only send whole GC tokens)
* Updated GC Token Description metadata to "Use GC tokens to purchase gumballs and candies from the sweet machines"
* Updated Candy Machine `buy_candy` and `buy_candy_with_membership_card` to no longer return a Bucket for excess funds.