### PR TITLE
fix: handle null error in useFetch hook

### DIFF
--- a/dapp/src/app/hooks/useFetch.ts
+++ b/dapp/src/app/hooks/useFetch.ts
@@ -21,7 +21,7 @@ export const useFetch = <T = any>() => {
       } catch (error: any) {
         setState({
           error: true,
-          errorMessage: parseJson(error.message),
+          errorMessage: parseJson(error?.message ?? 'An unknown error occurred'),
         })
       }
     }, []),


### PR DESCRIPTION
## Summary
- Add optional chaining and nullish coalescing fallback for `error.message` in the useFetch hook
- Prevents `TypeError: Cannot read properties of null (reading 'message')` when caught error is null or undefined

## Test plan
- [ ] Verify the app builds without errors
- [ ] Test error scenarios in the app to ensure error messages display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)